### PR TITLE
Allow usb-mitm to quit on Ctrl+C

### DIFF
--- a/src/tools/usb-mitm.cpp
+++ b/src/tools/usb-mitm.cpp
@@ -66,6 +66,7 @@ void handle_signal(int signum)
 			fprintf(stderr, "Exiting\n");
 			memset(&action, 0, sizeof(struct sigaction));
 			action.sa_handler = SIG_DFL;
+			sigaction(SIGINT, &action, NULL);
 			sigaction(SIGTERM, &action, NULL);
 			break;
 		case SIGHUP:


### PR DESCRIPTION
It does quit after third Ctrl+C but at least it does.
(It is related to issue #82)